### PR TITLE
Widen HeaderNames field to show *what* is allowed.

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -47,7 +47,7 @@
                 <label class="control-label" for="editor">@Messages("form.customHeaders")</label>
                 <div class="controls" id="advanced-block-inner">
                     <p class="clone">
-                        <input class="span2" type="text" name="headerNames[]"> :
+                        <input class="span3" type="text" name="headerNames[]"> :
                         <input class="span4" type="text" name="headerValues[]">
                         <a class="btn btn-success btn-mini btn-add-header"><i class="icon icon-plus icon-white"></i></a>
                     </p>


### PR DESCRIPTION
This allows me to see "Access-Control-Allow-Headers" instead of "Access-Control-Allow".

When I set 3 different headers that all start with "Access-Control-Allow..." I can't see where they differ unless I widen the field.