### PR TITLE
Text cut in dropdown and typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## What is mocky?
 
-Mocky is a simple app which allows to generate custom HTTP responses. It's helpful when you have to request a build-in-progress WS, when you want to mock the backend response in a singleapp, or when you want to test your WS client.
+Mocky is a simple app which allows to generate custom HTTP responses. It's helpful when you have to request a build-in-progress WS, when you want to mock the backend response in a single app, or when you want to test your WS client.
 
-Don't wait for the backend to be ready, generate custom API responses with Mocky and start working on your application straightaway
+Don't wait for the backend to be ready, generate custom API responses with Mocky and start working on your application straight away
 
 Mocky is a **free** and **unlimited** online service, accessible on **https://www.mocky.io**. Read the [FAQ](https://designer.mocky.io/faq) for more information about allowed usage.
 
@@ -16,7 +16,7 @@ _Everything is done to provide the best service quality, but I don't guarantee t
 
 ## How to host my own Mocky instance
 
-Work in progress. Please come back in a few days !
+Work in progress. Please come back in a few days!
 
 ## Architecture
 
@@ -36,7 +36,7 @@ See the [client/README.md](https://github.com/julien-lafont/Mocky/blob/master/cl
 
 Mocky is currently hosted on [Clever-Cloud](https://www.clever-cloud.com/en/).
 
-> Clever Cloud helps companies and IT professionals to achiveve software delivery faster, reduce their feedback loop, focus on their core value and stop worrying about their hosting infrastructure by providing a solution for application sustainability.
+> Clever Cloud helps companies and IT professionals to achieve software delivery faster, reduce their feedback loop, focus on their core value and stop worrying about their hosting infrastructure by providing a solution for application sustainability.
 
 ## Contributors
 

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Mocky: The world easiest & fastest tool to mock your APIs</title>
+    <title>Mocky: The world's easiest & fastest tool to mock your APIs</title>
     <meta
       name="description"
       content="Don't wait for the backend to be ready, generate custom API responses with Mocky and start working on your application straightaway"

--- a/client/src/modules/designer/form/styles.css
+++ b/client/src/modules/designer/form/styles.css
@@ -1,6 +1,7 @@
 .expiration-select select {
   font-size: 0.98em;
-  line-height: 0.98em;
+  padding-top: 0;
+  padding-bottom: 0;
   color: #333;
 }
 


### PR DESCRIPTION
- fix: text was being cut in the select dropdown
![image](https://user-images.githubusercontent.com/8295888/94894543-33339480-04a7-11eb-8308-a9de56572ebe.png)
- fix a few typos that I noticed along with it